### PR TITLE
Add missing headers in include/core

### DIFF
--- a/include/core/common.h
+++ b/include/core/common.h
@@ -14,6 +14,7 @@
 #include <unordered_set>
 #include <variant>
 #include <vector>
+#include <cstdint>
 
 namespace infini {
 using std::list;

--- a/include/core/op_type.h
+++ b/include/core/op_type.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <unordered_set>
+#include <cstdint>
 
 namespace infini
 {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/94eebf5c-b40b-40bb-bf3c-78abc90aa27a)
![image](https://github.com/user-attachments/assets/b425ccf0-526c-480d-a551-a9c994f0b14f)
The project cannot be built properly due to the lack of header file `<cstdint>`.

Environment: gcc/g++ 13.1.0; cmake 3.23.0; ubuntu 20.04