### PR TITLE
add missing headers to pass compilation on more gcc versions

### DIFF
--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "core/common.h"
+#include <cstdint>
 
 namespace infini {
 

--- a/include/core/graph.h
+++ b/include/core/graph.h
@@ -2,8 +2,8 @@
 #include "core/allocator.h"
 #include "core/operator.h"
 #include "core/tensor.h"
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 
 namespace infini
 {

--- a/include/core/graph.h
+++ b/include/core/graph.h
@@ -2,6 +2,8 @@
 #include "core/allocator.h"
 #include "core/operator.h"
 #include "core/tensor.h"
+#include <cstdint>
+#include <algorithm>
 
 namespace infini
 {

--- a/include/core/op_type.h
+++ b/include/core/op_type.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <unordered_set>
+#include <cstdint>
 
 namespace infini
 {

--- a/include/core/op_type.h
+++ b/include/core/op_type.h
@@ -2,9 +2,9 @@
 #ifndef OP_TYPE_H
 #define OP_TYPE_H
 
+#include <cstdint>
 #include <string>
 #include <unordered_set>
-#include <cstdint>
 
 namespace infini
 {


### PR DESCRIPTION
This project doesn't compile for GCC14.2 on my end, adding the following modification ensures headers are properly imported. 