### PR TITLE
docs: add installation instructions for GoogleTest

### DIFF
--- a/docs/项目部署.md
+++ b/docs/项目部署.md
@@ -1,3 +1,4 @@
+```
 ### 环境准备
 建议使用Linux系统或Mac系统，windows下使用WSL，配置方法和Linux一致。
 
@@ -11,7 +12,8 @@ brew install gcc
 ```
 
 2. 安装CMake，请确认版本为 3.17 及以上的稳定版本
-``` bash
+
+```bash
 # linux 使用apt安装
 sudo apt install cmake
 
@@ -19,13 +21,24 @@ sudo apt install cmake
 brew install cmake
 ```
 
-2. 安装make
-``` bash
+3. 安装make
+
+```bash
 # linux 使用apt安装
 sudo apt install make
 
 # mac 使用Homebrew安装
 brew install make
+```
+
+4. 安装googletest
+
+```bash
+# 先删除空目录 googletest
+rmdir googletest
+
+# 然后直接克隆到 TinyInfiniTensor/3rd-party 目录下
+git clone https://github.com/google/googletest.git
 ```
 
 ### 构建命令


### PR DESCRIPTION
# 解决 make 构建项目时出现的报错
```
`CMake Error at CMakeLists.txt:57 (add_subdirectory):
  add_subdirectory given source "3rd-party/googletest" which is not an
  existing directory.
```