### PR TITLE
clarify the features required for nativecpu testcases

### DIFF
--- a/docs/训练营作业介绍.md
+++ b/docs/训练营作业介绍.md
@@ -8,9 +8,9 @@
 4. test_concat：依赖作业五
 5. test_element_wise：依赖作业六
 6. test_transpose：依赖作业二
-7. test_nativecpu_concat：依赖作业一、作业五
-8. test_nativecpu_elementwise：依赖作业一、作业六
-9. test_nativecpu_transpose：依赖作业一、作业二
+7. test_nativecpu_concat：依赖作业一、作业五、作业八
+8. test_nativecpu_elementwise：依赖作业一、作业六、作业八
+9. test_nativecpu_transpose：依赖作业一、作业二、作业八
 10. test_matmul：依赖作业六、作业七
 11. test_graph：依赖作业八
 


### PR DESCRIPTION
所有的nativecpu测试都依赖图的内存分配，这里修改了下文档使得用户更明晰为什么那些testcase运行失败。